### PR TITLE
Update Manual Upgrade Guide

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -196,8 +196,8 @@ Topics:
 - Name: Upgrading using the roxctl CLI
   Dir: upgrading_roxctl
   Topics:
-  - Name: Upgrading from Red Hat Advanced Cluster Security for Kubernetes 3.0.44 or higher
-    File: upgrade-from-44
+  - Name: Upgrading from Red Hat Advanced Cluster Security for Kubernetes Manually
+    File: upgrade-manually
 ---
 Name: roxctl CLI
 Dir: cli

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -47,10 +47,7 @@ Topics:
   File: 3061-release-notes
 - Name: Red Hat Advanced Cluster Security for Kubernetes 3.0.60
   File: 3060-release-notes
-- Name: Red Hat Advanced Cluster Security for Kubernetes 3.0.59
-  File: 3059-release-notes
-- Name: Red Hat Advanced Cluster Security for Kubernetes 3.0.58
-  File: 3058-release-notes
+
 ---
 Name: Architecture
 Dir: architecture

--- a/modules/uninstall-roxctl-cli.adoc
+++ b/modules/uninstall-roxctl-cli.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-manually.adoc
+:_module-type: PROCEDURE
+[id="uninstalling-cli-on-linux_{context}"]
+= Uninstalling the roxctl CLI
+
+You can uninstall the `roxctl` CLI binary on Linux by using the following procedure.
+
+.Procedure
+
+. Find where `roxctl` is installed on your system and uninstall
++
+Depending on your environment, you may have to run this command with sudo.
++
+[source,terminal,subs=attributes+]
+----
+$ ROXPATH=$(which roxctl) && rm -f $ROXPATH
+----

--- a/modules/update-openshift-security-context-constraints.adoc
+++ b/modules/update-openshift-security-context-constraints.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * upgrade/upgrade-from-44.adoc
+// * upgrade/upgrade-manually.adoc
 :_module-type: PROCEDURE
 [id="update-openshift-security-context-constraints_{context}"]
 = Updating OpenShift security context constraints
@@ -15,14 +15,7 @@ Run the commands in this section only if you are using {product-title} with {ocp
 
 .Procedure
 
-* {product-title} 3.0.57.2 introduces changes to the SCCs. If you are upgrading to {product-title} 3.0.57.2 or higher, you must patch the SCCs by running the following command:
-+
-[source,terminal]
-----
-$ oc patch --type merge scc scanner -p '{"priority":0}'
-----
-
-* {product-title} 3.64.0 renames the SCCs. If you are upgrading to {product-title} 3.64.0 or higher, you must delete and reapply the SCCs:
+* {product-title} 3.64.0 renames the SCCs. If you are upgrading from a version below {product-title} 3.64.0, you must delete and reapply the SCCs, otherwise, skip this step:
 
 .. Run the following commands to update Central:
 +
@@ -122,7 +115,7 @@ EOF
 $ oc delete scc scanner
 ----
 
-.. Run the following commands to update Secured Cluster:
+.. Run the following commands on each OpenShift Secured Cluster:
 +
 [source,terminal]
 ----

--- a/modules/update-other-images.adoc
+++ b/modules/update-other-images.adoc
@@ -6,11 +6,7 @@
 = Updating other images
 
 [role="_abstract"]
-If you are upgrading {product-title} version between 3.0.44 and 3.0.54, you must update the Sensor and Collector images.
-
-.Prerequisites
-
-* You must be using {product-title} version between 3.0.44 and 3.0.54.
+You must update the sensor, collector and compliance images on each secured cluster when not using automatic upgrades. 
 
 [NOTE]
 ====
@@ -38,67 +34,5 @@ $ oc -n stackrox set image ds/collector compliance=registry.redhat.io/rh-acs/mai
 [source,terminal,subs=attributes+]
 ----
 $ oc -n stackrox set image ds/collector collector=registry.redhat.io/rh-acs/collector:{collector-version} <1>
-----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
-. Apply the patch for Sensor:
-+
-[WARNING]
-====
-Applying the patch for Sensor is only required when you are upgrading from a {product-title} version that is between 3.0.44 and 3.0.54.
-Otherwise, skip this step.
-====
-+
-[source,terminal]
-----
-$ oc -n stackrox patch deploy/sensor -p '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}],"volumeMounts":[{"name":"cache","mountPath":"/var/cache/stackrox"}]}],"volumes":[{"name":"cache","emptyDir":{}}]}}}}' <1>
-----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
-. Apply the following cluster role and cluster role binding:
-+
-[WARNING]
-====
-Applying the cluster role and the cluster role binding is only required when you are upgrading from a {product-title} version that is between 3.0.44 and 3.0.54.
-Otherwise, skip this step.
-====
-+
-[source,terminal]
-----
-$ oc -n stackrox apply -f - <<EOF <1>
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: stackrox:review-tokens
-  labels:
-    app.kubernetes.io/name: stackrox
-    auto-upgrade.stackrox.io/component: "sensor"
-  annotations:
-    owner: stackrox
-    email: "support@stackrox.com"
-rules:
-- resources:
-  - tokenreviews
-  apiGroups: ["authentication.k8s.io"]
-  verbs:
-  - create
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: stackrox:review-tokens-binding
-  labels:
-    app.kubernetes.io/name: stackrox
-    auto-upgrade.stackrox.io/component: "sensor"
-  annotations:
-    owner: stackrox
-    email: "support@stackrox.com"
-subjects:
-- kind: ServiceAccount
-  name: sensor
-  namespace: stackrox
-roleRef:
-  kind: ClusterRole
-  name: stackrox:review-tokens
-  apiGroup: rbac.authorization.k8s.io
-EOF
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.

--- a/modules/update-readiness-probes.adoc
+++ b/modules/update-readiness-probes.adoc
@@ -6,7 +6,7 @@
 = Update readiness probes
 
 [role="_abstract"]
-If you are upgrading from {product-title} 3.65.0, you must run the following additional command to update the readiness probe path.
+If you are upgrading from a version below {product-title} 3.65.0, you must run the following additional command to update the readiness probe path. If you are running a higher version than 3.65, skip this step.
 
 .Procedure
 

--- a/modules/upgrade-central.adoc
+++ b/modules/upgrade-central.adoc
@@ -10,10 +10,6 @@ You can update Central to the latest version by downloading and deploying the up
 .Prerequisites
 
 * If you deploy images from a private image registry, first push the new image into your private registry, and then replace your image registry for the commands in this section.
-* If you used Red Hat UBI-based images when you installed {product-title}, replace the image names for the commands in this section with the following UBI-based image names:
-** For Central, Sensor, and Compliance, use `\registry.redhat.io/rh-acs/main-rhel`
-** For Scanner, use `\registry.redhat.io/rh-acs/scanner-rhel` and `\registry.redhat.io/rh-acs/scanner-db-rhel`
-** For Collector, use `\registry.redhat.io/rh-acs/collector-rhel`
 
 .Procedure
 

--- a/modules/upgrade-scanner.adoc
+++ b/modules/upgrade-scanner.adoc
@@ -11,9 +11,6 @@ You can update Scanner to the latest version by using the `roxctl` CLI.
 
 * If you deploy images from a private image registry, first push the new image into your private registry, and then replace your image registry for the commands in this section.
 * If you used Red Hat UBI-based images when you installed {product-title}, replace the image names for the commands in this section with the following UBI-based image names:
-** For Central, Sensor, and Compliance, use `\registry.redhat.io/rh-acs/main-rhel`
-** For Scanner, use `\registry.redhat.io/rh-acs/scanner-rhel` and `\registry.redhat.io/rh-acs/scanner-db-rhel`
-** For Collector, use `\registry.redhat.io/rh-acs/collector-rhel`
 * If you have created custom scanner configurations, you must apply those changes before updating the scanner configuration file:
 +
 [source,terminal]
@@ -35,13 +32,6 @@ $ oc apply -f scanner-bundle/scanner/02-scanner-04-scanner-config.yaml <1>
 
 .Procedure
 
-. Apply the patch for Scanner:
-+
-[source,terminal]
-----
-$ oc -n stackrox patch hpa/scanner -p '{"spec":{"minReplicas":2}}' <1>
-----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 . Update the Scanner image:
 +
 [source,terminal,subs=attributes+]
@@ -65,13 +55,7 @@ $ oc -n stackrox set image deploy/scanner-db init-db=registry.redhat.io/rh-acs/s
 
 .Verification
 
-* Check that the new pods have deployed:
-+
-[source,terminal]
-----
-$ oc get deploy -n stackrox -o wide <1>
-----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+* Check that the new pods have deployed successfully:
 +
 [source,terminal]
 ----

--- a/modules/verify-last-check-in-time.adoc
+++ b/modules/verify-last-check-in-time.adoc
@@ -3,7 +3,7 @@
 // * upgrade/upgrade-from-44.adoc
 :_module-type: PROCEDURE
 [id="verify-last-check-in-time_{context}"]
-= Verifying last check-in time for secured clusters
+= Verifying upgrades
 
 [role="_abstract"]
 The updated Sensors and Collectors continue to report the latest data from each secured cluster.
@@ -11,12 +11,5 @@ The updated Sensors and Collectors continue to report the latest data from each 
 The last time Sensor contacted Central is visible in the RHACS portal.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Clusters*.
-. The cluster list shows the *Last check-in time* for each cluster.
-
-[NOTE]
-====
-* If any Sensor has not checked in for more than five minutes, check the cluster logs for that Sensor to ensure that it is operating as usual.
-* The displayed check-in time does not update automatically.
-You must reload the page to see the updates.
-====
+. On the RHACS portal, navigate to *Platform Configuration* -> *System Health*.
+. Check to ensure that Sensor Upgrade shows clusters up to date with Central.

--- a/upgrading/upgrading_roxctl/upgrade-manually.adoc
+++ b/upgrading/upgrading_roxctl/upgrade-manually.adoc
@@ -1,0 +1,87 @@
+[id="upgrade-manually"]
+= Upgrading from older {product-title} versions
+include::modules/common-attributes.adoc[]
+:context: upgrade-from-44
+
+toc::[]
+
+[role="_abstract"]
+Upgrade to the latest version of {product-title} from an older supported version.
+
+To upgrade {product-title} to the latest version, you must perform the following:
+
+* Backup the Central database
+* Upgrade Central
+* Upgrade the `roxctl` CLI
+* Upgrade Scanner
+* Ensure all secured clusters are upgraded
+
+include::modules/back-up-central-database.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../cli/getting-started-cli.adoc#cli-authentication_cli-getting-started[Authenticating using the roxctl CLI]
+
+[id="upgrade-central-cluster"]
+== Upgrading the Central cluster
+
+After you have backed up Central database, the start by upgrading Central.
+
+include::modules/upgrade-central.adoc[leveloffset=+2]
+
+[id="upgrade-roxctl-cli"]
+=== Upgrading the `roxctl` CLI
+
+To upgrade the `roxctl` CLI to the latest version perform the following steps:
+
+* Remove or uninstall roxctl
+* Install the latest version of roxctl
+
+include::modules/uninstall-roxctl-cli-linux.adoc[leveloffset=+3]
+include::modules/install-roxctl-cli-linux.adoc[leveloffset=+3]
+include::modules/install-roxctl-cli-macos.adoc[leveloffset=+3]
+include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
+
+[id="upgrade-scanner"]
+=== Upgrading scanner
+
+After you've upgraded roxctl you can upgrade scanner.
+
+include::modules/upgrade-scanner.adoc[leveloffset=+2]
+
+[id="verify upgrade"]
+=== Verifying the upgrade
+
+include::modules/verify-central-cluster-upgrade.adoc[leveloffset=+2]
+
+[id="upgrade-secured-clusters"]
+== Upgrading all secured clusters
+
+After upgrading Central services, you must upgrade all secured clusters.
+
+[IMPORTANT]
+====
+* If you are using automatic upgrades:
+** Update all your secured clusters by using automatic upgrades.
+** Skip the instructions in this section and follow the instructions in the xref:../../upgrading/upgrading_roxctl/upgrade-from-44.adoc#verify-last-check-in-time_{context}[Verifying last check-in time for secured clusters] and xref:../../upgrading/upgrading_roxctl/upgrade-from-44.adoc#revoke-the-api-token_{context}[Revoking the API token] sections.
+* If you are not using automatic upgrades, you must run the instructions in this section on all secured clusters including the Central cluster.
+====
+
+To complete manual upgrades of each secured cluster running Sensor, Collector, and Admission Controller, follow the instructions in this section.
+
+include::modules/update-readiness-probes.adoc[leveloffset=+2]
+
+include::modules/update-openshift-security-context-constraints.adoc[leveloffset=+2]
+
+include::modules/update-other-images.adoc[leveloffset=+2]
+
+include::modules/verify-secured-cluster-upgrade.adoc[leveloffset=+2]
+
+[id="rollback-central"]
+== Rolling back Central
+
+You can roll back to a previous version of Central if the upgrade to a new version is unsuccessful.
+
+include::modules/rollback-central-normal.adoc[leveloffset=+2]
+
+include::modules/verify-last-check-in-time.adoc[leveloffset=+1]


### PR DESCRIPTION
The manual upgrade guide today has a large number of no longer relevant instructions and several instructions that are contextually no longer correct. This PR seeks to update them to be as accurate as possible.