### PR TITLE
3.69 Secure Boot clarifications for Collector

### DIFF
--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -10,7 +10,7 @@ Use the following instructions to install the `secured-cluster-services` Helm ch
 
 [CAUTION]
 ====
-To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) boot, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages.
+To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. At the start Collector will identify Secure Boot status, and switch to eBPF probes if needed.
 ====
 
 .Prerequisites

--- a/modules/collector-requirements.adoc
+++ b/modules/collector-requirements.adoc
@@ -9,7 +9,7 @@ It connects to Sensor to report this information.
 
 [CAUTION]
 ====
-To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) secure boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. At the start Collector will identify secure boot status, and switch to eBPF probes if needed.
+To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. At the start Collector will identify Secure Boot status, and switch to eBPF probes if needed.
 ====
 
 [discrete]

--- a/modules/collector-requirements.adoc
+++ b/modules/collector-requirements.adoc
@@ -9,7 +9,7 @@ It connects to Sensor to report this information.
 
 [CAUTION]
 ====
-To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) boot, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages.
+To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. At the start Collector will identify Secure Boot status, and switch to eBPF probes if needed.
 ====
 
 [discrete]

--- a/modules/collector-requirements.adoc
+++ b/modules/collector-requirements.adoc
@@ -9,7 +9,7 @@ It connects to Sensor to report this information.
 
 [CAUTION]
 ====
-To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. At the start Collector will identify Secure Boot status, and switch to eBPF probes if needed.
+To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) secure boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. At the start Collector will identify secure boot status, and switch to eBPF probes if needed.
 ====
 
 [discrete]

--- a/modules/install-secured-cluster-operator.adoc
+++ b/modules/install-secured-cluster-operator.adoc
@@ -10,7 +10,7 @@ You can install secured cluster services on your clusters by using the `SecuredC
 
 [CAUTION]
 ====
-To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) boot, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages.
+To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. At the start Collector will identify Secure Boot status, and switch to eBPF probes if needed.
 ====
 
 .Prerequisites

--- a/modules/install-secured-cluster-services-helm-chart.adoc
+++ b/modules/install-secured-cluster-services-helm-chart.adoc
@@ -9,7 +9,7 @@ After you configure the `values-public.yaml` and `values-private.yaml` files, in
 
 [CAUTION]
 ====
-To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) boot, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages.
+To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. At the start Collector will identify Secure Boot status, and switch to eBPF probes if needed.
 ====
 
 .Procedure

--- a/modules/support-on-various-platforms.adoc
+++ b/modules/support-on-various-platforms.adoc
@@ -124,7 +124,7 @@ StackRox support recent Kubernetes and {ocp} versions, and test on managed Kuber
 [NOTE]
 ====
 
-Collector will not install on GKE clusters if you enable link:https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot[secure boot] because third-party unsigned kernel module, which are not signed by Google's CA, cannot be loaded when secure boot is enabled.
+To install Collector on GKE clusters with link:https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot[secure boot] enabled, you must use eBPF probes, because third-party unsigned kernel module, which are not signed by Google's CA, cannot be loaded when secure boot is enabled. At the start Collector will identify secure boot status, and switch to eBPF probes if needed.
 ====
 
 Along with other types of clusters, StackRox also supports clusters created by using the link:https://github.com/kubernetes/kops[kops - Kubernetes Operations] tool with the default configurations on Amazon Web Services (AWS).


### PR DESCRIPTION
Collector just became smarter about UEFI Secure Boot [1], and now will
switch to eBPF when needed to make the user experience smoother.
Represent this in the documentation, including clarification that
Collector will not work with kernel modules on UEFI when Secure Boot is
enabled (not on any system booted in UEFI mode).

[1] https://github.com/stackrox/collector/pull/553