### PR TITLE
update image values

### DIFF
--- a/modules/download-images-directly.adoc
+++ b/modules/download-images-directly.adoc
@@ -7,7 +7,7 @@
 
 If you do not want to use an image bundle, you can manually pull, retag, and push {product-title} images to your registry. The images included in the current version of the image bundles are:
 
-* `registry.redhat.io/rh-acs/main:{rhacs-version}`
-* `registry.redhat.io/rh-acs/scanner:{scanner-version}`
-* `registry.redhat.io/rh-acs/scanner-db:{scanner-version}`
-* `registry.redhat.io/rh-acs/collector:{collector-version}`
+* `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version}`
+* `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:{scanner-version}`
+* `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:{scanner-version}`
+* `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:{collector-version}`

--- a/modules/enable-offline-mode-roxctl.adoc
+++ b/modules/enable-offline-mode-roxctl.adoc
@@ -14,17 +14,17 @@ You can enable offline mode when you are installing {product-title} by using the
 +
 [source,terminal,subs=attributes+]
 ----
-Enter main image to use (default: "registry.redhat.io/rh-acs/main:{rhacs-version}"): <your_registry>/stackrox/main:{rhacs-version}
+Enter main image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version}"): <your_registry>/stackrox/main:{rhacs-version}
 ----
 +
 [source,terminal,subs=attributes+]
 ----
-Enter Scanner DB image to use (default: "registry.redhat.io/rh-acs/scanner-db:{scanner-version}"): <your_registry>/stackrox/scanner-db:{scanner-version}
+Enter Scanner DB image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:{scanner-version}"): <your_registry>/stackrox/scanner-db:{scanner-version}
 ----
 +
 [source,terminal,subs=attributes+]
 ----
-Enter Scanner image to use (default: "registry.redhat.io/rh-acs/scanner:{scanner-version}"): <your_registry>/stackrox/scanner:{scanner-version}
+Enter Scanner image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:{scanner-version}"): <your_registry>/stackrox/scanner:{scanner-version}
 ----
 . To enable the offline mode, enter `true` when answering the `Enter whether to run StackRox in offline mode` prompt:
 +

--- a/modules/retag-images.adoc
+++ b/modules/retag-images.adoc
@@ -12,12 +12,12 @@ You can download and retag images using the Docker command-line interface.
 When you retag an image, you must maintain the name of the image and the tag. For example, use:
 [source,terminal,subs=attributes+]
 ----
-$ docker tag registry.redhat.io/rh-acs/main:{rhacs-version} <your_registry>/main:{rhacs-version}
+$ docker tag registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version} <your_registry>/main:{rhacs-version}
 ----
 and do not retag like the following example:
 [source,terminal,subs=attributes+]
 ----
-$ docker tag registry.redhat.io/rh-acs/main:{rhacs-version} <your_registry>/other-name:latest
+$ docker tag registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version} <your_registry>/other-name:latest
 ----
 ====
 

--- a/modules/rollback-central-forced.adoc
+++ b/modules/rollback-central-forced.adoc
@@ -57,7 +57,7 @@ data:
 [source,terminal]
 ----
 $ oc -n stackrox \ <1>
-  set image deploy/central central=registry.redhat.io/rh-acs/main:<x.x.x.x> <2>
+  set image deploy/central central=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:<x.x.x.x> <2>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 <2> Specify the version that you want to roll back to. It must be the same version that you specified for the `maintenance.forceRollbackVersion` key in the `central-config` config map.

--- a/modules/run-roxctl-from-container.adoc
+++ b/modules/run-roxctl-from-container.adoc
@@ -20,14 +20,14 @@ $ docker login registry.redhat.io
 +
 [source,terminal,subs=attributes+]
 ----
-$ docker pull registry.redhat.io/rh-acs/roxctl:{rhacs-version}
+$ docker pull registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8:{rhacs-version}
 ----
 
 After you install the CLI, you can run it by using the following command:
 [source,terminal,subs=attributes+]
 ----
 $ docker run -e ROX_API_TOKEN=$ROX_API_TOKEN \
-  -it registry.redhat.io/rh-acs/roxctl:{rhacs-version} \
+  -it registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8:{rhacs-version} \
   -e $ROX_CENTRAL_ADDRESS <command>
 ----
 
@@ -37,5 +37,5 @@ $ docker run -e ROX_API_TOKEN=$ROX_API_TOKEN \
 +
 [source,terminal,subs=attributes+]
 ----
-$ docker run -it registry.redhat.io/rh-acs/roxctl:{rhacs-version} version
+$ docker run -it registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8:{rhacs-version} version
 ----

--- a/modules/update-other-images-40.adoc
+++ b/modules/update-other-images-40.adoc
@@ -61,19 +61,19 @@ $ oc -n stackrox patch deploy/sensor -p '{"spec":{"template":{"spec":{"container
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/sensor sensor=registry.redhat.io/rh-acs/main:{rhacs-version}
+$ oc -n stackrox set image deploy/sensor sensor=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version}
 ----
 . Update the Compliance image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector compliance=registry.redhat.io/rh-acs/main:{rhacs-version}
+$ oc -n stackrox set image ds/collector compliance=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version}
 ----
 . Update the Collector image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector collector=registry.redhat.io/rh-acs/collector:{collector-version}
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:{collector-version}
 ----
 . Apply the following cluster role and cluster role binding:
 +

--- a/modules/update-other-images.adoc
+++ b/modules/update-other-images.adoc
@@ -19,20 +19,20 @@ If you are using Kubernetes, use `kubectl` instead of `oc` for the commands list
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/sensor sensor=registry.redhat.io/rh-acs/main:{rhacs-version} <1>
+$ oc -n stackrox set image deploy/sensor sensor=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version} <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 . Update the Compliance image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector compliance=registry.redhat.io/rh-acs/main:{rhacs-version} <1>
+$ oc -n stackrox set image ds/collector compliance=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version} <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 . Update the Collector image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector collector=registry.redhat.io/rh-acs/collector:{collector-version} <1>
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:{collector-version} <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.

--- a/modules/upgrade-central-40.adoc
+++ b/modules/upgrade-central-40.adoc
@@ -11,9 +11,9 @@ You can update Central to the latest version by downloading and deploying the up
 
 * If you deploy images from a private image registry, first push the new image into your private registry, and then replace your image registry for the commands in this section.
 * If you used Red Hat UBI-based images when you installed {product-title}, replace the image names for the commands in this section with the following UBI-based image names:
-** For Central, Sensor, and Compliance, use `\registry.redhat.io/rh-acs/main-rhel`
-** For Scanner, use `\registry.redhat.io/rh-acs/scanner-rhel` and `\registry.redhat.io/rh-acs/scanner-db-rhel`
-** For Collector, use `\registry.redhat.io/rh-acs/collector-rhel`
+** For Central, Sensor, and Compliance, use `\registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8`
+** For Scanner, use `\registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8` and `\registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8`
+** For Collector, use `\registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8`
 
 .Procedure
 
@@ -31,7 +31,7 @@ $ oc -n stackrox patch scc central -p '{"priority": 0}'
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/central central=registry.redhat.io/rh-acs/main:{rhacs-version}
+$ oc -n stackrox set image deploy/central central=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version}
 ----
 . Optional: If you have installed Istio in your cluster, run the following additional command:
 +

--- a/modules/upgrade-central.adoc
+++ b/modules/upgrade-central.adoc
@@ -29,7 +29,7 @@ $ oc -n stackrox patch deployment/scanner -p '{"spec":{"template":{"spec":{"cont
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/central central=registry.redhat.io/rh-acs/main:{rhacs-version} <1>
+$ oc -n stackrox set image deploy/central central=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version} <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 +

--- a/modules/upgrade-scanner-40.adoc
+++ b/modules/upgrade-scanner-40.adoc
@@ -11,9 +11,9 @@ You can update Scanner to the latest version by using the `roxctl` CLI.
 
 * If you deploy images from a private image registry, first push the new image into your private registry, and then replace your image registry for the commands in this section.
 * If you used Red Hat UBI-based images when you installed {product-title}, replace the image names for the commands in this section with the following UBI-based image names:
-** For Central, Sensor, and Compliance, use `\registry.redhat.io/rh-acs/main-rhel`
-** For Scanner, use `\registry.redhat.io/rh-acs/scanner-rhel` and `\registry.redhat.io/rh-acs/scanner-db-rhel`
-** For Collector, use `\registry.redhat.io/rh-acs/collector-rhel`
+** For Central, Sensor, and Compliance, use `\registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8`
+** For Scanner, use `\registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8` and `\registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8`
+** For Collector, use `\registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8`
 
 .Procedure
 
@@ -56,18 +56,18 @@ $ oc -n stackrox patch hpa/scanner -p '{"spec":{"minReplicas":2}}'
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner scanner=registry.redhat.io/rh-acs/scanner:{scanner-version}
+$ oc -n stackrox set image deploy/scanner scanner=registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:{scanner-version}
 ----
 . Update the Scanner database image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db db=registry.redhat.io/rh-acs/scanner-db:{scanner-version}
+$ oc -n stackrox set image deploy/scanner-db db=registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:{scanner-version}
 ----
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db init-db=registry.redhat.io/rh-acs/scanner-db:{scanner-version}
+$ oc -n stackrox set image deploy/scanner-db init-db=registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:{scanner-version}
 ----
 . Optional: If you have installed Istio in your cluster, run the following additional command:
 +

--- a/modules/upgrade-scanner.adoc
+++ b/modules/upgrade-scanner.adoc
@@ -36,20 +36,20 @@ $ oc apply -f scanner-bundle/scanner/02-scanner-04-scanner-config.yaml <1>
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner scanner=registry.redhat.io/rh-acs/scanner:{scanner-version} <1>
+$ oc -n stackrox set image deploy/scanner scanner=registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:{scanner-version} <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 . Update the Scanner database image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db db=registry.redhat.io/rh-acs/scanner-db:{scanner-version} <1>
+$ oc -n stackrox set image deploy/scanner-db db=registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:{scanner-version} <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db init-db=registry.redhat.io/rh-acs/scanner-db:{scanner-version} <1>
+$ oc -n stackrox set image deploy/scanner-db init-db=registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:{scanner-version} <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 


### PR DESCRIPTION
This PR changes the image names from the `rh-acs` repository to the new CPaaS one `advanced-cluster-security`. 

Open points
- [ ] Offline mode changes regarding `stackrox.io` instructions were not updated. Discussion [here](url).
- [ ] UBI image references `rh-acs/main-rhel` were changed to regular main image: `advanced-cluster-security/rhacs-main-rhel8` (please confirm if this is correct)
- [ ] Upgrade instructions use variable for tag values `{scanner-version}` and `{collector-version}`. We need to make sure that those are according to the version unification. Should I change all occurrences to `{rhacs-version}` or should we update the variable value to have the same version as `main`?