### PR TITLE
RS-347: add mention to collector slim specific images

### DIFF
--- a/modules/update-other-images-40.adoc
+++ b/modules/update-other-images-40.adoc
@@ -75,6 +75,10 @@ $ oc -n stackrox set image ds/collector compliance=registry.redhat.io/advanced-c
 ----
 $ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:{rhacs-version}
 ----
+Or if you're using collector slim:
+----
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:{collector-version} <1>
+----
 . Apply the following cluster role and cluster role binding:
 +
 [source,terminal]

--- a/modules/update-other-images-40.adoc
+++ b/modules/update-other-images-40.adoc
@@ -77,7 +77,7 @@ $ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cl
 ----
 Or if you're using collector slim:
 ----
-$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:{collector-version} <1>
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:{collector-version}
 ----
 . Apply the following cluster role and cluster role binding:
 +

--- a/modules/update-other-images-40.adoc
+++ b/modules/update-other-images-40.adoc
@@ -77,7 +77,7 @@ $ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cl
 ----
 Or if you're using collector slim:
 ----
-$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:{collector-version}
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:{rhacs-version}
 ----
 . Apply the following cluster role and cluster role binding:
 +

--- a/modules/update-other-images.adoc
+++ b/modules/update-other-images.adoc
@@ -33,7 +33,7 @@ $ oc -n stackrox set image ds/collector compliance=registry.redhat.io/advanced-c
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:{rhacs-version}
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:{rhacs-version} <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 

--- a/modules/update-other-images.adoc
+++ b/modules/update-other-images.adoc
@@ -33,8 +33,10 @@ $ oc -n stackrox set image ds/collector compliance=registry.redhat.io/advanced-c
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:{rhacs-version} <1>
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:{rhacs-version}
 ----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+
 Or if you're using collector slim:
 ----
 $ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:{collector-version} <1>

--- a/modules/update-other-images.adoc
+++ b/modules/update-other-images.adoc
@@ -35,4 +35,8 @@ $ oc -n stackrox set image ds/collector compliance=registry.redhat.io/advanced-c
 ----
 $ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:{rhacs-version} <1>
 ----
+Or if you're using collector slim:
+----
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:{collector-version} <1>
+----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.

--- a/modules/update-other-images.adoc
+++ b/modules/update-other-images.adoc
@@ -39,6 +39,6 @@ $ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cl
 
 Or if you're using collector slim:
 ----
-$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:{collector-version} <1>
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:{rhacs-version} <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.


### PR DESCRIPTION
Not sure how this will look on the UI, might need some adjustments. 

Since we're changing the image reference pattern for `slim`/`full` collector images, might be worthwhile explicitly noting both flavors here. 